### PR TITLE
Increase sleep time to fix AntiAFK

### DIFF
--- a/src/main/java/me/night0721/lilase/events/ChatReceivedEvent.java
+++ b/src/main/java/me/night0721/lilase/events/ChatReceivedEvent.java
@@ -102,11 +102,11 @@ public class ChatReceivedEvent {
                     Utils.addTitle("You got sent to Limbo or Lobby!");
                     Flipper.state = FlipperState.NONE;
                     if (Lilase.cofl.isOpen()) Lilase.cofl.toggleAuction();
-                    Thread.sleep(5000 + new Random().nextInt(500));
+                    Thread.sleep(30000 + new Random().nextInt(5000));
                     Utils.sendServerMessage("/lobby");
-                    Thread.sleep(5000 + new Random().nextInt(500));
+                    Thread.sleep(30000 + new Random().nextInt(5000));
                     Utils.sendServerMessage("/skyblock");
-                    Thread.sleep(5000 + new Random().nextInt(500));
+                    Thread.sleep(30000 + new Random().nextInt(5000));
                     Utils.sendServerMessage("/hub");
                     if (!Lilase.cofl.isOpen()) Lilase.cofl.toggleAuction();
 //                     Thread bzchillingthread = new Thread(bazaarChilling);


### PR DESCRIPTION
As I understand, it executes command even before entered the server. New time should avoid it, but it's just a workaround. You should somehow wait for world to load + 5 seconds.

BTW, commands in limbo execute much slower, increase timeout there in ~3 times in the future.